### PR TITLE
cleanup: update files, bump Vib version to 0.6.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ref: https://git-scm.com/docs/gitattributes
+* text=auto eol=lf

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: 1.21
 
@@ -25,7 +25,7 @@ jobs:
         go build -trimpath -buildmode=plugin -o plugin.so -v ./...
 
     - name: Upload an artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         Name: Vib plugin
         path: ./plugin.so

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 
 # vib-fsguard
 
-[vib](https://github.com/vanilla-os/vib) plugin that sets up fsguard and generates a filelist
+[Vib](https://github.com/vanilla-os/vib) plugin that sets up fsguard and generates a filelist.
+
 This plugin requires that `minisign` is installed in the image, this can be easily done with a nested module
 
 ## Module Structure
+
 ```yaml
 - name: fsguard
   type: fsguard
@@ -19,7 +21,9 @@ This plugin requires that `minisign` is installed in the image, this can be easi
         packages:
             - "minisign"
 ```
-if `GenerateKey` is set to false, `KeyPath` has to be specified, pointing to a location in the container (e.g. added through includes.container) which contains already existing minisign keys:
+
+If `GenerateKey` is set to false, `KeyPath` has to be specified, pointing to a location in the container (e.g. added through includes.container) which contains already existing minisign keys:
+
 ```yaml
 - name: fsguard
   type: fsguard
@@ -34,9 +38,10 @@ if `GenerateKey` is set to false, `KeyPath` has to be specified, pointing to a l
       sources:
         packages:
             - "minisign" 
-``` 
-note that the keys must be named `minisign.pub` (public) and `minisign.key` (private) in this example the minisign keys would be in `includes.container/etc/minisign/`, which translates to `/etc/minisign** in the build environment
+```
 
-keep in mind that the minisign key **cannot** be password protected, as there is no way for the user to type in the password during building (which is why always generting a random key through GenerateKey is recommended)
+Note that the keys must be named `minisign.pub` (public) and `minisign.key` (private) in this example the minisign keys would be in `includes.container/etc/minisign/`, which translates to `/etc/minisign** in the build environment
+
+Keep in mind that the minisign key **cannot** be password protected, as there is no way for the user to type in the password during building (which is why always generting a random key through GenerateKey is recommended)
 
 In the case that FsGuard has to be manually built (due to a configuration change or similiar), the `CustomFsGuard` option has to be set to True, this stops the module from fetching a prebuilt FsGuard and instead allows the user to manually build FsGuard, it does however expect the FsGuard binary to be at `/sources/FsGuard`

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
 module github.com/vanilla-os/vib-fsguard
 
-
 go 1.21
 
 require (
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/vanilla-os/vib/api v0.0.0-20231203164136-c843eaca2af6
+	github.com/vanilla-os/vib/api v0.0.0-20240323151200-ee1fb88cbbfa
 )

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/vanilla-os/vib/api v0.0.0-20231203164136-c843eaca2af6 h1:J9h3w+pi9ZhhXDS+d/9IxWNbJ4hSMlUU8HFrF5RTtWE=
 github.com/vanilla-os/vib/api v0.0.0-20231203164136-c843eaca2af6/go.mod h1:vjJzDfFxfFHN5O2hcMwGM9De3+H9gGa00Pr3Um6EmCA=
+github.com/vanilla-os/vib/api v0.0.0-20240323151200-ee1fb88cbbfa h1:j1itnO1xevZdHFS9cXJ7aSiG0OoHnSRVgBKaEMevFO4=
+github.com/vanilla-os/vib/api v0.0.0-20240323151200-ee1fb88cbbfa/go.mod h1:vjJzDfFxfFHN5O2hcMwGM9De3+H9gGa00Pr3Um6EmCA=


### PR DESCRIPTION
## Changes

- Bump actions versions.
- Set default line ending (eol) to LF using `.gitattributes`.
- Add dependabot configuration.
- Minor fixes to Markdown syntax and wording.
- Bump Vib API (dep) to the latest version in `go.mod`.