### PR TITLE
fix: update source path for fsguard binary

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -96,7 +96,6 @@ func signFileList(module *FsGuardModule) {
 	mainCommands = append(mainCommands, "cat /FsGuard/filelist.minisig >> /FsGuard/signature")
 	mainCommands = append(mainCommands, "echo -n \"----begin second attach----\" >> /FsGuard/signature")
 	mainCommands = append(mainCommands, fmt.Sprintf("tail -n1 %s/minisign.pub >> /FsGuard/signature", module.KeyPath))
-	mainCommands = append(mainCommands, fmt.Sprintf("cat /FsGuard/signature >> /sources/%s/FsGuard", module.Name))
 }
 
 //export PlugInfo
@@ -143,7 +142,8 @@ func BuildModule(moduleInterface *C.char, recipeInterface *C.char, arch *C.char)
 		return C.CString(fmt.Sprintf("ERROR: %s", err.Error()))
 	}
 
-	cleanCommands = append(cleanCommands, fmt.Sprintf("mv /sources/%s/FsGuard %s", module.Name, module.FsGuardLocation))
+	cleanCommands = append(cleanCommands, fmt.Sprintf("mv /sources/%s/FsGuard*/FsGuard %s", module.Name, module.FsGuardLocation))
+	cleanCommands = append(cleanCommands, fmt.Sprintf("cat /FsGuard/signature >> %s", module.FsGuardLocation))
 
 	if module.GenerateKey {
 		prepCommands = append(prepCommands, "minisign -WG -s ./minisign.key")

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -19,13 +19,13 @@ var test = []testCases{
 	// No custom, location /fsguard, generate key, keypath /fsguard/keys, filelists /bin
 	{
 		FsGuardModule{Name: "testCase1", CustomFsGuard: false, FsGuardLocation: "/fsguard", GenerateKey: true, KeyPath: "/fsguard/keys", FilelistPaths: []string{"/bin"}},
-		"mkdir /FsGuard && chmod +x /sources/testCase1/genfilelist.py && minisign -WG -s ./minisign.key && python3 /sources/testCase1/genfilelist.py /bin /FsGuard/filelist /fsguard && minisign -Sm /FsGuard/filelist -p .//minisign.pub -s .//minisign.key && touch /FsGuard/signature && echo -n \"----begin attach----\" >> /FsGuard/signature && cat /FsGuard/filelist.minisig >> /FsGuard/signature && echo -n \"----begin second attach----\" >> /FsGuard/signature && tail -n1 .//minisign.pub >> /FsGuard/signature && cat /FsGuard/signature >> /sources/testCase1/FsGuard && mv /sources/testCase1/FsGuard /fsguard && rm ./minisign.key ./minisign.pub",
+		"mkdir /FsGuard && chmod +x /sources/testCase1/genfilelist.py && minisign -WG -s ./minisign.key && python3 /sources/testCase1/genfilelist.py /bin /FsGuard/filelist /fsguard && minisign -Sm /FsGuard/filelist -p .//minisign.pub -s .//minisign.key && touch /FsGuard/signature && echo -n \"----begin attach----\" >> /FsGuard/signature && cat /FsGuard/filelist.minisig >> /FsGuard/signature && echo -n \"----begin second attach----\" >> /FsGuard/signature && tail -n1 .//minisign.pub >> /FsGuard/signature && mv /sources/testCase1/FsGuard*/FsGuard /fsguard && cat /FsGuard/signature >> /fsguard && rm ./minisign.key ./minisign.pub",
 	},
 
 	// With custom, location /fsguard, dont generate key, keypath /fsguard/keys, filelists /bin
 	{
 		FsGuardModule{Name: "testCase2", CustomFsGuard: true, FsGuardLocation: "/fsguard", GenerateKey: false, KeyPath: "/fsguard/keys", FilelistPaths: []string{"/bin"}},
-		"mkdir /FsGuard && chmod +x /sources/testCase2/genfilelist.py && python3 /sources/testCase2/genfilelist.py /bin /FsGuard/filelist /fsguard && minisign -Sm /FsGuard/filelist -p /fsguard/keys/minisign.pub -s /fsguard/keys/minisign.key && touch /FsGuard/signature && echo -n \"----begin attach----\" >> /FsGuard/signature && cat /FsGuard/filelist.minisig >> /FsGuard/signature && echo -n \"----begin second attach----\" >> /FsGuard/signature && tail -n1 /fsguard/keys/minisign.pub >> /FsGuard/signature && cat /FsGuard/signature >> /sources/testCase2/FsGuard && mv /sources/testCase2/FsGuard /fsguard",
+		"mkdir /FsGuard && chmod +x /sources/testCase2/genfilelist.py && python3 /sources/testCase2/genfilelist.py /bin /FsGuard/filelist /fsguard && minisign -Sm /FsGuard/filelist -p /fsguard/keys/minisign.pub -s /fsguard/keys/minisign.key && touch /FsGuard/signature && echo -n \"----begin attach----\" >> /FsGuard/signature && cat /FsGuard/filelist.minisig >> /FsGuard/signature && echo -n \"----begin second attach----\" >> /FsGuard/signature && tail -n1 /fsguard/keys/minisign.pub >> /FsGuard/signature && mv /sources/testCase2/FsGuard*/FsGuard /fsguard && cat /FsGuard/signature >> /fsguard",
 	},
 }
 


### PR DESCRIPTION
This PR fixes the issue where the fsguard binary is not copied correctly.